### PR TITLE
Cross-platform support: macOS + Linux (incl. AIM XRK via libxrk)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,16 +210,20 @@ OpenLap is free and always will be. If you want to see more/faster progress, ple
 
 ## Run from source
 
+Works on Windows, macOS, and Linux.
+
 **Requirements**
 
 - Python 3.10+
-- FFmpeg available on your system `PATH`
+- FFmpeg available on your system `PATH` (`brew install ffmpeg` on macOS)
 
 **Install Python dependencies**
 
 ```bash
 pip install -e .
 ```
+
+On macOS the Cocoa backend is already pulled in via PyObjC when pywebview is installed, so no extra step is needed. If you see errors about `AppKit` or `WebKit`, make sure pywebview itself was installed successfully.
 
 For RaceBox cloud download (optional):
 
@@ -235,6 +239,11 @@ python main.py
 ```
 
 Configuration is stored at `~/.openlap/config.json`.
+
+**Known macOS limitations**
+
+- AIM `.xrk` / `.xrz` / `.drk` conversion is unavailable — AIM only ships the required `MatLabXRK` library as a Windows DLL. RaceBox CSV, MoTeC `.ld`, and GPX files work normally.
+- Hardware-accelerated encoding uses **VideoToolbox** (`h264_videotoolbox`). NVENC / AMF / QSV are Windows/Linux only.
 
 ---
 

--- a/frontend/js/pages/settings.js
+++ b/frontend/js/pages/settings.js
@@ -98,9 +98,9 @@
     <!-- AIM Mychron DLL -->
     <section class="settings-section">
       <div class="section-title">AIM Mychron</div>
-      <p class="section-hint">AIM .xrk / .xrz / .drk files are converted to CSV automatically on scan. This requires the MatLabXRK DLL provided free by AIM.</p>
+      <p class="section-hint">AIM .xrk / .xrz / .drk files are converted to CSV automatically on scan.</p>
       <div id="aim-dll-status" class="form-row" style="font-size:10px;color:var(--text3)">Checking…</div>
-      <div class="form-row" style="margin-top:6px">
+      <div class="form-row" id="aim-dll-row" style="margin-top:6px">
         <button class="btn btn-secondary" id="aim-dll-btn">Download DLL</button>
         <span id="aim-dll-msg" class="status-msg"></span>
       </div>
@@ -389,13 +389,26 @@
     // AIM DLL status + download
     function _refreshAimStatus() {
       API.aimDllStatus().then(r => {
-        const el = $('aim-dll-status');
+        const el  = $('aim-dll-status');
+        const row = $('aim-dll-row');
         if (!el) return;
-        if (r && r.found) {
+        const found        = !!(r && r.found);
+        const libxrkOK     = !!(r && r.libxrk_available);
+        const xrkSupported = !!(r && r.xrk_supported);
+        const isWindows    = !!(r && r.is_windows);
+
+        if (found) {
           el.innerHTML = '<span style="color:var(--ok)">● MatLabXRK DLL found — AIM XRK conversion available.</span>';
+        } else if (libxrkOK) {
+          el.innerHTML = '<span style="color:var(--ok)">● libxrk available — AIM XRK conversion available (cross-platform reader).</span>';
+        } else if (isWindows) {
+          el.innerHTML = '<span style="color:var(--text3)">○ MatLabXRK DLL not found — click below to install, or `pip install libxrk` for the cross-platform reader.</span>';
         } else {
-          el.innerHTML = '<span style="color:var(--text3)">○ MatLabXRK DLL not found — AIM XRK conversion unavailable.</span>';
+          el.innerHTML = '<span style="color:var(--text3)">○ XRK reader not installed — run `pip install libxrk` and restart OpenLap.</span>';
         }
+
+        // The DLL-download button only helps on Windows; hide it elsewhere.
+        if (row) row.style.display = isWindows ? '' : 'none';
       }).catch(() => {});
     }
     _refreshAimStatus();

--- a/main.py
+++ b/main.py
@@ -49,7 +49,14 @@ def main():
 
     api = WebviewAPI()
 
-    _icon = str(_BASE / 'frontend' / 'icon.ico')
+    # pywebview's `icon` is only honored by the Windows (edgechromium/mshtml)
+    # and Linux (GTK/QT) backends. On macOS the cocoa backend takes its icon
+    # from the app bundle's Info.plist, so we skip it entirely there.
+    _icon: str | None = None
+    if sys.platform != 'darwin':
+        candidate = str(_BASE / 'frontend' / 'icon.ico')
+        if os.path.isfile(candidate):
+            _icon = candidate
 
     window = webview.create_window(
         title      = 'OpenLap',
@@ -65,8 +72,7 @@ def main():
 
     # Use GUI thread blocking call — webview.start() must be on main thread.
     # Disable DevTools in packaged builds; keep enabled when running from source.
-    webview.start(debug=not getattr(sys, 'frozen', False),
-                  icon=_icon if os.path.isfile(_icon) else None)
+    webview.start(debug=not getattr(sys, 'frozen', False), icon=_icon)
 
 
 if __name__ == '__main__':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "openlap"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ dependencies = [
     "opencv-python>=4.8",
     "pandas>=2.0",
     "pywebview>=5.0",
+    # AIM XRK reader. Windows has the option of the AIM-distributed MatLabXRK
+    # DLL (downloaded at runtime from aim-sportline.com); macOS/Linux must use
+    # libxrk because AIM does not ship a native binary for those platforms.
+    "libxrk>=0.10; sys_platform != 'win32'",
 ]
 
 [project.optional-dependencies]

--- a/session_scanner.py
+++ b/session_scanner.py
@@ -195,26 +195,41 @@ def convert_xrk_files(folder: str, progress_cb: Optional[Callable[[str], None]] 
     if not pending:
         return []
 
+    import sys as _sys
+
     try:
         import xrk_to_csv as _xrk
     except ImportError:
-        if progress_cb:
-            progress_cb("xrk_to_csv.py not found — XRK conversion skipped")
-        return []
+        _xrk = None
 
-    # Locate (or download) the DLL once for all files
-    if progress_cb:
-        progress_cb("Locating AIM MatLabXRK DLL…")
-    try:
-        dll_path = _xrk._find_dll()
-    except SystemExit as e:
+    # Pick a reader: Windows DLL first (with auto-download), falling back to
+    # libxrk (cross-platform PyPI package). We only invoke _find_dll() on
+    # Windows because its auto-download path can open a Playwright browser
+    # — useless on macOS/Linux where AIM ships no native binary anyway.
+    dll_path = None
+    if _xrk is not None and _sys.platform == 'win32':
         if progress_cb:
-            progress_cb(f"XRK DLL unavailable: {e}")
-        return []
-    except Exception as e:
-        if progress_cb:
-            progress_cb(f"XRK DLL error: {e}")
-        return []
+            progress_cb("Locating AIM MatLabXRK DLL…")
+        try:
+            dll_path = _xrk._find_dll()
+        except SystemExit as e:
+            if progress_cb:
+                progress_cb(f"XRK DLL unavailable, falling back to libxrk: {e}")
+        except Exception as e:
+            if progress_cb:
+                progress_cb(f"XRK DLL error, falling back to libxrk: {e}")
+
+    libxrk_fn = None
+    if not dll_path:
+        try:
+            from xrk_to_csv_libxrk import xrk_to_csv_libxrk as libxrk_fn
+        except ImportError:
+            if progress_cb:
+                progress_cb(
+                    "XRK reader unavailable — install libxrk (`pip install libxrk`) "
+                    "or place a MatLabXRK DLL next to OpenLap (Windows only)."
+                )
+            return []
 
     new_csvs: List[str] = []
     for i, (xrk_path, csv_path) in enumerate(pending):
@@ -224,7 +239,10 @@ def convert_xrk_files(folder: str, progress_cb: Optional[Callable[[str], None]] 
         try:
             buf = _io.StringIO()
             with contextlib.redirect_stdout(buf):
-                _xrk.xrk_to_csv(xrk_path, csv_path, dll_path)
+                if dll_path:
+                    _xrk.xrk_to_csv(xrk_path, csv_path, dll_path)
+                else:
+                    libxrk_fn(xrk_path, csv_path)
             new_csvs.append(csv_path)
         except SystemExit as e:
             if progress_cb:

--- a/webview_api.py
+++ b/webview_api.py
@@ -941,7 +941,8 @@ class WebviewAPI:
         ffmpeg_bin = os.environ.get('FFMPEG_BIN') or shutil.which('ffmpeg')
         if not ffmpeg_bin:
             base = sys._MEIPASS if getattr(sys, 'frozen', False) else os.path.dirname(os.path.abspath(__file__))
-            candidate = os.path.join(base, 'ffmpeg.exe')
+            fname = 'ffmpeg.exe' if sys.platform == 'win32' else 'ffmpeg'
+            candidate = os.path.join(base, fname)
             if os.path.isfile(candidate):
                 ffmpeg_bin = candidate
         if not ffmpeg_bin:

--- a/webview_api.py
+++ b/webview_api.py
@@ -996,7 +996,14 @@ class WebviewAPI:
 
     # ── AIM DLL status ────────────────────────────────────────────────────────
     def aim_dll_status(self) -> dict:
-        """Return whether the AIM MatLabXRK DLL is present."""
+        """Return AIM XRK reader availability.
+
+        Two readers exist:
+          - Windows-only MatLabXRK DLL (downloaded from aim-sportline.com)
+          - Cross-platform libxrk (PyPI; ships native wheels for win/mac/linux)
+        Either one is sufficient for XRK conversion. Frontend uses
+        `xrk_supported` to decide whether to show AIM-related UI.
+        """
         import glob as _glob, sys, os
         from pathlib import Path
         # Persistent user directory is checked first so the DLL survives app rebuilds.
@@ -1005,11 +1012,26 @@ class WebviewAPI:
             search_dirs += [sys._MEIPASS, os.path.dirname(sys.executable)]
         else:
             search_dirs.append(os.path.dirname(os.path.abspath(__file__)))
+        dll_path = ''
         for base in search_dirs:
             dlls = _glob.glob(os.path.join(base, 'MatLabXRK*.dll'))
             if dlls:
-                return {'found': True, 'path': dlls[0]}
-        return {'found': False, 'path': ''}
+                dll_path = dlls[0]
+                break
+
+        try:
+            import libxrk  # noqa: F401
+            libxrk_available = True
+        except ImportError:
+            libxrk_available = False
+
+        return {
+            'found': bool(dll_path),
+            'path': dll_path,
+            'libxrk_available': libxrk_available,
+            'xrk_supported': bool(dll_path) or libxrk_available,
+            'is_windows': sys.platform == 'win32',
+        }
 
     def download_aim_dll(self) -> dict:
         """Download the AIM MatLabXRK DLL from aim-sportline.com in a background thread.
@@ -1068,7 +1090,6 @@ class WebviewAPI:
         if not actual_xrk:
             return {'ok': False, 'error': 'XRK source file not found'}
         try:
-            import xrk_to_csv as _xrk
             import glob as _glob, sys
             from pathlib import Path
             search_dirs = [str(Path.home() / '.openlap')]
@@ -1081,7 +1102,12 @@ class WebviewAPI:
                  for d in [_glob.glob(os.path.join(base, 'MatLabXRK*.dll'))] if d),
                 None
             )
-            _xrk.xrk_to_csv(actual_xrk, csv_path, dll_path)
+            if dll_path:
+                import xrk_to_csv as _xrk
+                _xrk.xrk_to_csv(actual_xrk, csv_path, dll_path)
+            else:
+                from xrk_to_csv_libxrk import xrk_to_csv_libxrk
+                xrk_to_csv_libxrk(actual_xrk, csv_path)
             return {'ok': True}
         except Exception as e:
             return {'ok': False, 'error': str(e)}

--- a/xrk_to_csv_libxrk.py
+++ b/xrk_to_csv_libxrk.py
@@ -1,0 +1,177 @@
+"""
+xrk_to_csv_libxrk.py — cross-platform XRK→CSV converter using libxrk.
+
+Produces output byte-identical in schema to xrk_to_csv.py (the Windows DLL
+path), so aim_data.load_csv() can consume either without changes:
+
+    # Session-Date: 2026-04-19T09:30:39Z
+    Time (s),Lap,GPS Speed [m/s],GPS Latitude [deg],...
+    0.000000,0,...
+
+libxrk ships native wheels (Cython + Rust) for Windows, macOS, and Linux,
+so this path is the only viable AIM reader on macOS/Linux where AIM only
+distributes a Windows DLL.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+# libxrk channel names differ slightly from the AIM MatLabXRK DLL's naming.
+# aim_data.load_csv() resolves channels via fuzzy substring patterns that were
+# tuned against DLL output, so we rename libxrk channels here to keep the
+# downstream loader source-agnostic.
+#
+#   libxrk             →  DLL-style (what aim_data.py expects)
+#   GPS_InlineAcc      →  GPS_LonAcc      (longitudinal G — gforce_x)
+#   GPS_LateralAcc     →  GPS_LatAcc      (lateral G       — gforce_y)
+#
+# Channels with units 'rpm' that are NOT engine RPM ('Jackshaft' = rear-wheel
+# tach on a kart) are emitted with no units, otherwise aim_data's loose 'rpm'
+# pattern matches them in alphabetical order before the real RPM column.
+_CHANNEL_RENAMES: dict[str, str] = {
+    'GPS_InlineAcc':  'GPS_LonAcc',
+    'GPS_LateralAcc': 'GPS_LatAcc',
+}
+_DROP_UNITS_FOR: set[str] = {'Jackshaft'}
+
+
+def _parse_session_date(metadata: dict) -> Optional[str]:
+    """Build an ISO8601 'Z' string from libxrk metadata Log Date / Log Time."""
+    date_str = (metadata.get('Log Date') or '').strip()
+    time_str = (metadata.get('Log Time') or '').strip()
+    if not date_str:
+        return None
+    candidates = ['%m/%d/%Y %H:%M:%S', '%m/%d/%Y'] if time_str else ['%m/%d/%Y']
+    combined = f'{date_str} {time_str}'.strip() if time_str else date_str
+    for fmt in candidates:
+        try:
+            return datetime.strptime(combined, fmt).strftime('%Y-%m-%dT%H:%M:%SZ')
+        except ValueError:
+            continue
+    return None
+
+
+def _build_lap_column(timecodes_ms, laps_table) -> list[int]:
+    """Assign each timecode the lap number whose [start_time, end_time) covers it.
+
+    libxrk laps table: columns num (int32), start_time (int64 ms), end_time (int64 ms).
+    Convention matches the DLL path: lap 0 = outlap, 1+ = timed laps.
+    """
+    import bisect
+    starts = laps_table.column('start_time').to_pylist()
+    nums   = laps_table.column('num').to_pylist()
+    pairs  = sorted(zip(starts, nums))
+    sorted_starts = [p[0] for p in pairs]
+    sorted_nums   = [p[1] for p in pairs]
+
+    out: list[int] = []
+    for tc in timecodes_ms:
+        idx = bisect.bisect_right(sorted_starts, tc) - 1
+        out.append(sorted_nums[idx] if idx >= 0 else 0)
+    return out
+
+
+def xrk_to_csv_libxrk(xrk_path: str, csv_path: str) -> None:
+    """Convert an AIM .xrk/.xrz/.drk file to CSV using libxrk.
+
+    Output format matches xrk_to_csv.xrk_to_csv() exactly so aim_data.load_csv()
+    works against the result without modification.
+    """
+    try:
+        import pandas as pd
+    except ImportError:
+        raise ImportError("pandas is required.  pip install pandas")
+
+    try:
+        from libxrk import aim_xrk
+    except ImportError as e:
+        raise ImportError(
+            "libxrk is required for AIM XRK conversion on non-Windows platforms.\n"
+            "  pip install libxrk"
+        ) from e
+
+    log = aim_xrk(xrk_path)
+
+    logger.info('File    : %s', xrk_path)
+    logger.info('Vehicle : %s', log.metadata.get('Vehicle', ''))
+    logger.info('Track   : %s', log.metadata.get('Venue', ''))
+    logger.info('Driver  : %s', log.metadata.get('Driver', ''))
+
+    session_date_str = _parse_session_date(log.metadata)
+    if session_date_str:
+        logger.info('Date    : %s', session_date_str)
+
+    table = log.get_channels_as_table()
+    if table.num_rows == 0:
+        raise RuntimeError(f"No channel data found in {xrk_path!r}")
+    if 'timecodes' not in table.column_names:
+        raise RuntimeError(
+            f"libxrk table missing 'timecodes' column "
+            f"(got: {table.column_names[:5]}…)"
+        )
+
+    timecodes_ms = table.column('timecodes').to_pylist()
+    lap_col = _build_lap_column(timecodes_ms, log.laps)
+
+    df = table.drop(['timecodes']).to_pandas()
+
+    # Build renamed columns: rename libxrk-specific names to DLL conventions,
+    # then suffix with units (skipping units for known wheel-speed channels so
+    # aim_data.py's loose `rpm` matcher binds to engine RPM only).
+    new_cols = {}
+    for field in table.schema:
+        if field.name == 'timecodes':
+            continue
+        renamed = _CHANNEL_RENAMES.get(field.name, field.name)
+        units = ''
+        if field.metadata:
+            raw = field.metadata.get(b'units', b'') or b''
+            try:
+                units = raw.decode('utf-8').strip()
+            except (UnicodeDecodeError, AttributeError):
+                units = ''
+        if renamed in _DROP_UNITS_FOR:
+            units = ''
+        new_cols[field.name] = f'{renamed} [{units}]' if units else renamed
+    df = df.rename(columns=new_cols)
+
+    df.insert(0, 'Lap', lap_col)
+
+    df.index = [round(tc / 1000.0, 6) for tc in timecodes_ms]
+    df.index.name = 'Time (s)'
+    df.sort_index(inplace=True)
+
+    logger.info('Writing %d rows × %d columns → %s',
+                len(df), len(df.columns), csv_path)
+    with open(csv_path, 'w', newline='', encoding='utf-8') as fout:
+        if session_date_str:
+            fout.write(f'# Session-Date: {session_date_str}\n')
+        df.to_csv(fout)
+    logger.info('Done.')
+
+
+if __name__ == '__main__':
+    import argparse
+    import os
+    import sys
+
+    logging.basicConfig(level=logging.INFO, format='%(message)s')
+
+    parser = argparse.ArgumentParser(
+        description='Convert an AIM .xrk/.xrz/.drk file to CSV using libxrk.',
+    )
+    parser.add_argument('xrk', help='Input .xrk file')
+    parser.add_argument('csv', nargs='?', help='Output .csv (default: alongside input)')
+    args = parser.parse_args()
+
+    csv_out = args.csv or os.path.splitext(os.path.abspath(args.xrk))[0] + '.csv'
+    try:
+        xrk_to_csv_libxrk(args.xrk, csv_out)
+    except Exception as e:
+        sys.exit(f'ERROR: {e}')


### PR DESCRIPTION
## Summary

Adds first-class macOS and Linux support to OpenLap. The app already used cross-platform Python libraries (numpy, scipy, opencv, pywebview, etc.), but a few hardcoded Windows assumptions (`.ico` icon, `ffmpeg.exe` fallback, AIM DLL) blocked it from launching cleanly off Windows. This PR removes those blockers and adds a cross-platform AIM XRK reader so the AIM Mychron path is no longer Windows-only.

Closes the cross-platform gap without affecting any Windows code path: every change is either platform-gated by `sys.platform` or a plain bug fix that helps Windows too (e.g. the `pyproject.toml` `build-backend` fix that blocked `pip install -e .` on a fresh system).

## Why

- **macOS:** the app would error on launch (unable to open the `.ico` icon, unable to find `ffmpeg.exe`, no AIM XRK reader). Three small platform gates and a libxrk integration fix all of it.
- **Linux:** same story as macOS — same fixes apply because they're all gated on `sys.platform != 'win32'`.
- **AIM XRK files:** AIM only distributes their MatLabXRK reader as a Windows DLL. Mac/Linux users had no way to convert `.xrk` / `.xrz` / `.drk`. This PR adds [`libxrk`](https://pypi.org/project/libxrk/) as a fallback — it's a Cython+Rust XRK parser that ships native wheels for win/mac/linux on PyPI, so no scraping or runtime downloads needed off-Windows.

The Windows DLL path is preserved exactly as it was. On Windows, the new code defers to the existing DLL flow first and only falls back to libxrk if a user explicitly skips the DLL.

## What changed

### Platform gates (Commit 1: macOS launch fixes)
- **`main.py`** — Skip `icon=` on macOS. Cocoa pywebview ignores it anyway (icon comes from the bundle's Info.plist), but passing a missing `.ico` path was throwing.
- **`webview_api.py`** — `check_encoders()` fallback ffmpeg binary is now `'ffmpeg.exe' if sys.platform == 'win32' else 'ffmpeg'` (was hardcoded to `.exe`).
- **`pyproject.toml`** — `build-backend = "setuptools.build_meta"` (was `setuptools.backends.legacy:build`, which blocks `pip install -e .` on any modern system).
- **`README.md`** — Added macOS install steps + a "Known macOS / Linux limitations" note.

### Cross-platform AIM XRK reader (Commit 2: libxrk integration)
- **New `xrk_to_csv_libxrk.py`** — libxrk-based XRK→CSV converter. Output is byte-compatible with the existing DLL path (`# Session-Date:` header, `Time (s)` index, `Lap` column, `Channel [units]` column names) so `aim_data.load_csv()` consumes either reader's output unchanged. Renames libxrk's `GPS_InlineAcc`/`GPS_LateralAcc` to `GPS_LonAcc`/`GPS_LatAcc` and strips the `[rpm]` units from the `Jackshaft` column so `aim_data.py`'s fuzzy matcher binds the right channels (longitudinal G, lateral G, engine RPM).
- **`session_scanner.py` / `webview_api.py`** — `convert_xrk_files()` and `convert_xrk_session()` now dispatch: Windows DLL first (existing behavior preserved exactly, including the auto-download), libxrk fallback otherwise. `_find_dll()` is no longer called on non-Windows where its Playwright-fallback path would open a useless browser.
- **`webview_api.aim_dll_status()`** — Now also returns `libxrk_available`, `xrk_supported`, and `is_windows`. Backward-compatible: `found` and `path` still mean what they meant.
- **`frontend/js/pages/settings.js`** — Settings UI shows the appropriate status line (DLL found / libxrk available / install hint) and hides the "Download DLL" button on non-Windows where it can't help.
- **`pyproject.toml`** — `libxrk>=0.10; sys_platform != 'win32'`. Auto-installs on Mac/Linux; Windows users skip it entirely (avoids ~125MB of pyarrow on Windows where the DLL path is the default anyway).

## Validation

- **macOS arm64 (M-series):** All 11 of my real `.xrk` files (35-channel AIM Mychron logs, 4-22MB each) convert via libxrk in 4.9s total and round-trip cleanly through `aim_data.load_csv()` — correct lap counts (9-14 per session), best-lap times in expected range, GPS / RPM / lateral-G / longitudinal-G / exhaust-temp all binding to the right channels.
- **Tests:** `pytest tests/ -q` — **200 passed, 13 skipped** (the 13 skips are pre-existing Windows-only XRK tests; same skip count on Windows-with-DLL today, just for different reasons there).
- **JS tests:** `npm run test:run` — **39 passed** (one note: Node 25 ships an `localStorage` stub that shadows jsdom's; on Node 25+ run with `NODE_OPTIONS=--no-experimental-webstorage` or apply a small vitest setupFile workaround. Pre-existing, unrelated to this PR — happy to file a follow-up).

## What's still Windows-only after this PR

These are out of scope here but worth flagging for follow-up:

1. **`OpenLap.spec` / `.exe` packaging** — Hardcoded `ffmpeg.exe`/`ffprobe.exe`, bundles 5 Windows DLLs, imports `webview.platforms.winforms` and `clr`/pythonnet. Mac/Linux users run from source. A second PR could `sys.platform`-branch this for `.app` / AppImage builds.
2. **NVENC / AMF / QSV hardware encoders** — Not in this PR's scope, but worth noting: macOS has `h264_videotoolbox` (already in the encoder probe list). Linux users with NVIDIA/Intel/AMD GPUs would need `h264_nvenc` / `h264_vaapi` added to the probe list to detect them.
3. **`download_aim_dll`** — Still callable on non-Windows; the UI hides the button so this is harmless, but a clean fix would have it return `{ok: false, error: 'Windows-only'}` early on non-Windows.
4. **Standalone `python xrk_to_csv.py` CLI** — Still ctypes/DLL-based. The in-app conversion now uses libxrk on non-Windows, so this is dev-only and could either be deleted or wrapped to dispatch.

