### PR TITLE
Add RPM field to data model

### DIFF
--- a/data_model.py
+++ b/data_model.py
@@ -52,7 +52,7 @@ class DataPoint:
             gyro_z     = float(row['GyroZ']),
             lean_angle = -float(row.get('LeanAngle', 0.0)) if is_bike else 0.0,
             # FIX: Only convert to float if raw_rpm is not None/empty string, else default to 0.0
-            rpm        = float(row.get('Rpm') or row.get('rpm')) if (row.get('Rpm') or row.get('rpm')) not in (None, "", "None", 0.0) else 0.0,
+            rpm        = float(row.get('Rpm', row.get('rpm', 0.0)) or 0.0),
         )
 
 

--- a/data_model.py
+++ b/data_model.py
@@ -51,12 +51,8 @@ class DataPoint:
             gyro_y     = float(row['GyroY']),
             gyro_z     = float(row['GyroZ']),
             lean_angle = -float(row.get('LeanAngle', 0.0)) if is_bike else 0.0,
-            # FIX: Fall back to 0.0 if 'Rpm' is missing (case-insensitive fallback included for safety)
-            #rpm        = float(row.get('Rpm', row.get('rpm', 0.0))),
             # FIX: Only convert to float if raw_rpm is not None/empty string, else default to 0.0
-            # FIX: Safely parse missing keys, empty strings, or None values inline
             rpm        = float(row.get('Rpm') or row.get('rpm')) if (row.get('Rpm') or row.get('rpm')) not in (None, "", "None", 0.0) else 0.0,
-
         )
 
 

--- a/data_model.py
+++ b/data_model.py
@@ -51,7 +51,12 @@ class DataPoint:
             gyro_y     = float(row['GyroY']),
             gyro_z     = float(row['GyroZ']),
             lean_angle = -float(row.get('LeanAngle', 0.0)) if is_bike else 0.0,
-            rpm        = float(row['Rpm']),
+            # FIX: Fall back to 0.0 if 'Rpm' is missing (case-insensitive fallback included for safety)
+            #rpm        = float(row.get('Rpm', row.get('rpm', 0.0))),
+            # FIX: Only convert to float if raw_rpm is not None/empty string, else default to 0.0
+            # FIX: Safely parse missing keys, empty strings, or None values inline
+            rpm        = float(row.get('Rpm') or row.get('rpm')) if (row.get('Rpm') or row.get('rpm')) not in (None, "", "None", 0.0) else 0.0,
+
         )
 
 

--- a/data_model.py
+++ b/data_model.py
@@ -51,7 +51,8 @@ class DataPoint:
             gyro_y     = float(row['GyroY']),
             gyro_z     = float(row['GyroZ']),
             lean_angle = -float(row.get('LeanAngle', 0.0)) if is_bike else 0.0,
-            # FIX: Only convert to float if raw_rpm is not None/empty string, else default to 0.0
+            # Optional: not in stock RaceBox exports, but present on some custom
+            # RaceBox-format devices. 'or 0.0' covers missing/empty/None values.
             rpm        = float(row.get('Rpm', row.get('rpm', 0.0)) or 0.0),
         )
 

--- a/data_model.py
+++ b/data_model.py
@@ -51,6 +51,7 @@ class DataPoint:
             gyro_y     = float(row['GyroY']),
             gyro_z     = float(row['GyroZ']),
             lean_angle = -float(row.get('LeanAngle', 0.0)) if is_bike else 0.0,
+            rpm        = float(row['Rpm']),
         )
 
 

--- a/main.py
+++ b/main.py
@@ -72,7 +72,8 @@ def main():
 
     # Use GUI thread blocking call — webview.start() must be on main thread.
     # Disable DevTools in packaged builds; keep enabled when running from source.
-    webview.start(debug=not getattr(sys, 'frozen', False), icon=_icon)
+    # pop-os 24.04 needs "private_mode=False" or user videos are no shown on Data window
+    webview.start(debug=not getattr(sys, 'frozen', False), icon=_icon, private_mode=False)
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -12,14 +12,6 @@ import os
 import sys
 from pathlib import Path
 
-import matplotlib
-# Use the headless Agg backend explicitly
-matplotlib.use('Agg')
-# FORCE WINDOWS-LIKE TEXT SAFETY BOUNDS ON LINUX
-# This tells Matplotlib to render text safely by fallback pathways 
-# rather than passing extreme vector coordinates to your Linux glibc FreeType library.
-matplotlib.rcParams['text.usetex'] = False
-matplotlib.rcParams['svg.fonttype'] = 'path'
 
 def _setup_logging() -> None:
     log_dir = Path.home() / '.openlap' / 'logs'
@@ -80,8 +72,7 @@ def main():
 
     # Use GUI thread blocking call — webview.start() must be on main thread.
     # Disable DevTools in packaged builds; keep enabled when running from source.
-    # pop-os 24.04 needs "private_mode=False" or user videos are no shown on Data window
-    webview.start(debug=not getattr(sys, 'frozen', False), icon=_icon, private_mode=False)
+    webview.start(debug=not getattr(sys, 'frozen', False), icon=_icon)
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -12,6 +12,14 @@ import os
 import sys
 from pathlib import Path
 
+import matplotlib
+# Use the headless Agg backend explicitly
+matplotlib.use('Agg')
+# FORCE WINDOWS-LIKE TEXT SAFETY BOUNDS ON LINUX
+# This tells Matplotlib to render text safely by fallback pathways 
+# rather than passing extreme vector coordinates to your Linux glibc FreeType library.
+matplotlib.rcParams['text.usetex'] = False
+matplotlib.rcParams['svg.fonttype'] = 'path'
 
 def _setup_logging() -> None:
     log_dir = Path.home() / '.openlap' / 'logs'

--- a/tests/test_racebox_data.py
+++ b/tests/test_racebox_data.py
@@ -21,6 +21,40 @@ def test_detect_bike_requires_both_conditions():
     assert _detect_bike(cols) is False
 
 
+# ── DataPoint.from_row — RPM (optional field on custom RaceBox-format devices) ──
+
+def _base_row(**overrides):
+    row = {
+        'Record': '0', 'Time': '2024-06-15T10:00:00Z',
+        'Latitude': '50.0', 'Longitude': '4.0', 'Altitude': '100.0',
+        'Speed': '120.0', 'GForceX': '0.1', 'GForceY': '0.2', 'GForceZ': '1.0',
+        'Lap': '1', 'GyroX': '0.0', 'GyroY': '0.0', 'GyroZ': '0.0',
+    }
+    row.update(overrides)
+    return row
+
+
+def test_from_row_rpm_defaults_to_zero_when_column_absent():
+    # Stock RaceBox exports have no Rpm column — must not regress to a crash or non-zero value
+    pt = DataPoint.from_row(_base_row(), is_bike=False)
+    assert pt.rpm == pytest.approx(0.0)
+
+
+def test_from_row_rpm_parses_pascal_case_column():
+    pt = DataPoint.from_row(_base_row(Rpm='8500'), is_bike=False)
+    assert pt.rpm == pytest.approx(8500.0)
+
+
+def test_from_row_rpm_parses_lowercase_column():
+    pt = DataPoint.from_row(_base_row(rpm='7200'), is_bike=False)
+    assert pt.rpm == pytest.approx(7200.0)
+
+
+def test_from_row_rpm_empty_string_defaults_to_zero():
+    pt = DataPoint.from_row(_base_row(Rpm=''), is_bike=False)
+    assert pt.rpm == pytest.approx(0.0)
+
+
 # ── load_csv — basic session shape ─────────────────────────────────────────────
 
 def test_load_csv_car_is_not_bike(racebox_car_session):


### PR DESCRIPTION
data_model.py now returns RPM value

I made that change to use a modified racebox template, adding the RPM field for a custom-made device that outputs data in the same fashion that racebox uses,