### PR TITLE
Fix gauge text overflow at the root: shrink-to-fit font sizing

### DIFF
--- a/frontend/js/gauges/bar.js
+++ b/frontend/js/gauges/bar.js
@@ -89,11 +89,12 @@ const GaugeBar = {
     }
 
     // Value text (between bar and sparkline)
-    const valStr = unit ? `${value.toFixed(1)} ${unit}` : value.toFixed(1);
+    const valStr    = unit ? `${value.toFixed(1)} ${unit}` : value.toFixed(1);
+    const fsValFit  = GaugeBase.fitFontSize(ctx, valStr, fsVal, 'bold', barW);
     ctx.textAlign    = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillStyle    = fillCol || theme.fillLo;
-    ctx.font         = `bold ${fsVal}px 'Segoe UI', sans-serif`;
+    ctx.font         = `bold ${fsValFit}px 'Segoe UI', sans-serif`;
     ctx.fillText(valStr, w * 0.5, h * 0.25);
 
     // Sparkline (bottom zone: 5%–27% of height)

--- a/frontend/js/gauges/base.js
+++ b/frontend/js/gauges/base.js
@@ -184,6 +184,31 @@ function scaleFont(baseSize, w, h, baseW = 120, baseH = 160) {
 }
 
 /**
+ * Shrink a font size so `text` rendered at that size does not exceed maxWidthPx.
+ * Mirrors fit_text_to_width() in overlay_utils.py.
+ *
+ * Sets ctx.font as a side effect (to fontSizePx) so ctx.measureText reflects the
+ * candidate size; caller must re-set ctx.font with the returned size before drawing.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {string} text
+ * @param {number} fontSizePx    — candidate size (upper bound) to start from
+ * @param {string} fontWeight    — e.g. '' or 'bold'
+ * @param {number} maxWidthPx    — available width budget in px
+ * @param {number} minFontSizePx — floor for the shrunk size
+ * @param {string} fontFamily    — must match the family the caller will draw with
+ * @returns {number} fontSizePx, shrunk if necessary
+ */
+function fitFontSize(ctx, text, fontSizePx, fontWeight, maxWidthPx, minFontSizePx = 8, fontFamily = "'Segoe UI', sans-serif") {
+  ctx.font = `${fontWeight} ${fontSizePx}px ${fontFamily}`.trim();
+  const width = ctx.measureText(text).width;
+  if (width <= maxWidthPx || width <= 0) return fontSizePx;
+  // Never grow past fontSizePx — if it's already <= minFontSizePx, the best we
+  // can do is leave it alone rather than clamp upward to minFontSizePx.
+  return Math.min(fontSizePx, Math.max(minFontSizePx, Math.floor(fontSizePx * (maxWidthPx / width))));
+}
+
+/**
  * Format a numeric gauge value to a display string.
  * Mirrors the formatting logic in gauge_numeric.py.
  *
@@ -221,4 +246,4 @@ function fmtTime(secs) {
 }
 
 // Export as a namespace object (no ES module build step required)
-const GaugeBase = { getTheme, roundRect, drawBackground, drawAccentBar, scaleFont, fmtValue, fmtTime, THEMES };
+const GaugeBase = { getTheme, roundRect, drawBackground, drawAccentBar, scaleFont, fitFontSize, fmtValue, fmtTime, THEMES };

--- a/frontend/js/gauges/compare.js
+++ b/frontend/js/gauges/compare.js
@@ -134,12 +134,13 @@ const GaugeCompare = {
     ctx.font         = `${fsLabel}px 'Segoe UI', sans-serif`;
     ctx.fillText(label, w * 0.04, h * 0.05);
 
-    // Value (right panel, top)
-    const valStr = GaugeBase.fmtValue(value, channel);
+    // Value (right panel, top) — budget is the panel right of the chart area.
+    const valStr   = GaugeBase.fmtValue(value, channel);
+    const fsValFit = GaugeBase.fitFontSize(ctx, valStr, fsVal, 'bold', w * 0.97 - (cX + cW));
     ctx.textBaseline = 'top';
     ctx.textAlign    = 'right';
     ctx.fillStyle    = lineCol;
-    ctx.font         = `bold ${fsVal}px 'Segoe UI', sans-serif`;
+    ctx.font         = `bold ${fsValFit}px 'Segoe UI', sans-serif`;
     ctx.fillText(valStr, w * 0.97, h * 0.08);
 
     if (unit) {

--- a/frontend/js/gauges/delta.js
+++ b/frontend/js/gauges/delta.js
@@ -42,8 +42,9 @@ const GaugeDelta = {
     ctx.fillText(label, w * 0.5, h * 0.20);
 
     // Value
+    const fsValueFit = GaugeBase.fitFontSize(ctx, txt, fsValue, 'bold', w * 0.90);
     ctx.fillStyle  = colour;
-    ctx.font       = `bold ${fsValue}px 'Segoe UI', sans-serif`;
+    ctx.font       = `bold ${fsValueFit}px 'Segoe UI', sans-serif`;
     ctx.fillText(txt, w * 0.5, h * 0.54);
 
     // Sparkline (bottom 18% of height)

--- a/frontend/js/gauges/dial.js
+++ b/frontend/js/gauges/dial.js
@@ -136,8 +136,15 @@ const GaugeDial = {
     ctx.textAlign    = 'center';
     ctx.textBaseline = 'middle';
 
+    // Horizontal budget = chord of the track ring at the value text's vertical
+    // offset, so long strings shrink instead of poking outside the ring.
+    const valueDy      = R * 0.15;
+    const chordHalf     = Math.sqrt(Math.max(0, R_TRACK * R_TRACK - valueDy * valueDy));
+    const valueMaxWidth = chordHalf * 2 * 0.85;
+    const fsValueFit    = GaugeBase.fitFontSize(ctx, valStr, fsValue, 'bold', valueMaxWidth);
+
     ctx.fillStyle  = theme.text;
-    ctx.font       = `bold ${fsValue}px 'Segoe UI', sans-serif`;
+    ctx.font       = `bold ${fsValueFit}px 'Segoe UI', sans-serif`;
     ctx.fillText(valStr, cx, cy + R * 0.15);
 
     ctx.fillStyle = theme.unit;

--- a/frontend/js/gauges/gmeter.js
+++ b/frontend/js/gauges/gmeter.js
@@ -101,13 +101,15 @@ const GaugeGmeter = {
 
     // G readout (bottom of background area)
     const fsVal = Math.max(8, Math.round(dim * 0.065));
-    ctx.fillStyle    = '#ccccdd';
-    ctx.font         = `${fsVal}px 'Segoe UI', sans-serif`;
-    ctx.textAlign    = 'center';
-    ctx.textBaseline = 'bottom';
     const gxStr = (gxNow >= 0 ? '+' : '') + gxNow.toFixed(2);
     const gyStr = (gyNow >= 0 ? '+' : '') + gyNow.toFixed(2);
-    ctx.fillText(`${gxStr}  /  ${gyStr}`, w * 0.5, h * 0.97);
+    const gReadout = `${gxStr}  /  ${gyStr}`;
+    const fsValFit = GaugeBase.fitFontSize(ctx, gReadout, fsVal, '', w * 0.90);
+    ctx.fillStyle    = '#ccccdd';
+    ctx.font         = `${fsValFit}px 'Segoe UI', sans-serif`;
+    ctx.textAlign    = 'center';
+    ctx.textBaseline = 'bottom';
+    ctx.fillText(gReadout, w * 0.5, h * 0.97);
 
     // History trace (fading alpha)
     const nTrace = Math.min(60, gxHist.length);

--- a/frontend/js/gauges/info.js
+++ b/frontend/js/gauges/info.js
@@ -79,8 +79,9 @@ const GaugeInfo = {
       ctx.font      = `${fsLabel}px 'Segoe UI', sans-serif`;
       ctx.fillText(lbl, padL, yLbl);
 
+      const fsValueFit = GaugeBase.fitFontSize(ctx, val, fsValue, 'bold', w - padL * 2);
       ctx.fillStyle  = theme.text;
-      ctx.font       = `bold ${fsValue}px 'Segoe UI', sans-serif`;
+      ctx.font       = `bold ${fsValueFit}px 'Segoe UI', sans-serif`;
       ctx.fillText(val, padL, yVal);
     }
   }

--- a/frontend/js/gauges/lean.js
+++ b/frontend/js/gauges/lean.js
@@ -111,10 +111,16 @@ const GaugeLean = {
     const direction = value > 0 ? 'R' : (value < 0 ? 'L' : '');
     const valStr    = `${direction}${absLean.toFixed(1)}${unit}`;
 
+    // Horizontal budget = chord of the background circle at the value text's
+    // vertical offset, so long strings shrink instead of poking outside it.
+    const valueDy   = R * 0.82;
+    const chordHalf = Math.sqrt(Math.max(0, R * R - valueDy * valueDy));
+    const fsValFit  = GaugeBase.fitFontSize(ctx, valStr, fsVal, 'bold', chordHalf * 2 * 0.85);
+
     ctx.textAlign    = 'center';
     ctx.textBaseline = 'middle';
     ctx.fillStyle    = leanCol;
-    ctx.font         = `bold ${fsVal}px 'Segoe UI', sans-serif`;
+    ctx.font         = `bold ${fsValFit}px 'Segoe UI', sans-serif`;
     ctx.fillText(valStr, cx, cy + R * 0.82);
 
     ctx.fillStyle = theme.label;

--- a/frontend/js/gauges/line.js
+++ b/frontend/js/gauges/line.js
@@ -111,12 +111,14 @@ const GaugeLine = {
     ctx.font         = `${fsLabel}px 'Segoe UI', sans-serif`;
     ctx.fillText(label, w * 0.04, h * 0.05);
 
-    // Value readout (right panel, upper half)
-    const valStr = GaugeBase.fmtValue(value, channel);
+    // Value readout (right panel, upper half) — budget is the panel right of
+    // the chart area (from cX+cW to the right edge).
+    const valStr   = GaugeBase.fmtValue(value, channel);
+    const fsValFit = GaugeBase.fitFontSize(ctx, valStr, fsVal, 'bold', w * 0.97 - (cX + cW));
     ctx.textBaseline = 'middle';
     ctx.textAlign    = 'right';
     ctx.fillStyle    = lineCol;
-    ctx.font         = `bold ${fsVal}px 'Segoe UI', sans-serif`;
+    ctx.font         = `bold ${fsValFit}px 'Segoe UI', sans-serif`;
     ctx.fillText(valStr, w * 0.97, h * 0.44);
 
     if (unit) {

--- a/frontend/js/gauges/multiline.js
+++ b/frontend/js/gauges/multiline.js
@@ -156,10 +156,12 @@ const GaugeMultiline = {
       if (unit) valStr += '\u202f' + unit;
 
       // Combined label + value
-      const combined = `${label.padEnd(6)}  ${valStr}`;
+      const combined  = `${label.padEnd(6)}  ${valStr}`;
+      const textX     = legendX + swatchW + 4;
+      const fsLegFit  = GaugeBase.fitFontSize(ctx, combined, fsLeg, 'bold', w - textX - w * 0.02);
       ctx.fillStyle  = colour;
-      ctx.font       = `bold ${fsLeg}px 'Segoe UI', sans-serif`;
-      ctx.fillText(combined, legendX + swatchW + 4, yCentre);
+      ctx.font       = `bold ${fsLegFit}px 'Segoe UI', sans-serif`;
+      ctx.fillText(combined, textX, yCentre);
     }
   }
 };

--- a/frontend/js/gauges/numeric.js
+++ b/frontend/js/gauges/numeric.js
@@ -40,7 +40,8 @@ const GaugeNumeric = {
     ctx.font      = `${fsLabel}px 'Segoe UI', sans-serif`;
     ctx.fillText(label, w * 0.5, h * 0.22);
 
-    // Value (centre)
+    // Value (centre) — shrink to fit so long strings never overflow the gauge
+    fsValue = GaugeBase.fitFontSize(ctx, txt, fsValue, 'bold', w * 0.90);
     ctx.fillStyle  = theme.text;
     ctx.font       = `bold ${fsValue}px 'Segoe UI', sans-serif`;
     ctx.fillText(txt, w * 0.5, h * 0.50);

--- a/frontend/js/gauges/scoreboard.js
+++ b/frontend/js/gauges/scoreboard.js
@@ -86,10 +86,12 @@ const GaugeScoreboard = {
       ctx.font      = `${fsLabel}px 'Segoe UI', sans-serif`;
       ctx.fillText(lbl, padL, yLbl);
 
-      // Value (right-aligned, monospace)
+      // Value (right-aligned, monospace) — budget is the right ~55% of the row
+      // so a long value shrinks instead of running under the label column.
+      const fsValueFit = GaugeBase.fitFontSize(ctx, val, fsValue, 'bold', w * 0.55, 8, "'Consolas', monospace");
       ctx.textAlign  = 'right';
       ctx.fillStyle  = col;
-      ctx.font       = `bold ${fsValue}px 'Consolas', monospace`;
+      ctx.font       = `bold ${fsValueFit}px 'Consolas', monospace`;
       ctx.fillText(val, w * 0.97, yVal);
     }
   }

--- a/frontend/js/gauges/sector_bar.js
+++ b/frontend/js/gauges/sector_bar.js
@@ -75,8 +75,9 @@ const GaugeSectorBar = {
       // Delta
       const sign   = s.delta >= 0 ? '+' : '';
       const dStr   = `${sign}${s.delta.toFixed(2)}`;
+      const fsFit  = GaugeBase.fitFontSize(ctx, dStr, fs, 'bold', boxW * 0.90);
       ctx.fillStyle = 'white';
-      ctx.font      = `bold ${fs}px 'Segoe UI', sans-serif`;
+      ctx.font      = `bold ${fsFit}px 'Segoe UI', sans-serif`;
       ctx.fillText(dStr, cursor + boxW / 2, boxY1 + boxH * 0.68);
 
       cursor += boxW + GAP;

--- a/frontend/js/gauges/splits.js
+++ b/frontend/js/gauges/splits.js
@@ -42,6 +42,8 @@ const GaugeSplits = {
     const COL_REF  = w * 0.38;
     const COL_CUR  = w * 0.62;
     const COL_DIFF = w * 0.87;
+    // Per-column width budget for shrink-to-fit (columns are ~0.24-0.26w apart)
+    const COL_BUDGET = w * 0.20;
 
     // Header
     const yHdr = yTop - rowH * 0.45;
@@ -72,20 +74,25 @@ const GaugeSplits = {
 
       ctx.textAlign    = 'center';
       ctx.textBaseline = 'middle';
-      ctx.font         = `${fsRow}px 'Segoe UI', sans-serif`;
 
       // Sector number
+      const sNumTxt = `S${s.num ?? (i + 1)}`;
       ctx.fillStyle = theme.text;
-      ctx.fillText(`S${s.num ?? (i + 1)}`, COL_S, rowY);
+      ctx.font      = `${GaugeBase.fitFontSize(ctx, sNumTxt, fsRow, '', COL_BUDGET)}px 'Segoe UI', sans-serif`;
+      ctx.fillText(sNumTxt, COL_S, rowY);
 
       // Ref time
+      const refTxt = s.ref_t != null ? s.ref_t.toFixed(2) : '\u2014';
       ctx.fillStyle = '#888888';
-      ctx.fillText(s.ref_t != null ? s.ref_t.toFixed(2) : '\u2014', COL_REF, rowY);
+      ctx.font      = `${GaugeBase.fitFontSize(ctx, refTxt, fsRow, '', COL_BUDGET)}px 'Segoe UI', sans-serif`;
+      ctx.fillText(refTxt, COL_REF, rowY);
 
       if (s.cur_t != null) {
         // Current time
+        const curTxt = s.cur_t.toFixed(2);
         ctx.fillStyle = theme.text;
-        ctx.fillText(s.cur_t.toFixed(2), COL_CUR, rowY);
+        ctx.font      = `${GaugeBase.fitFontSize(ctx, curTxt, fsRow, '', COL_BUDGET)}px 'Segoe UI', sans-serif`;
+        ctx.fillText(curTxt, COL_CUR, rowY);
 
         // Delta
         if (s.delta != null) {
@@ -93,13 +100,14 @@ const GaugeSplits = {
           if (Math.abs(s.delta) < 0.01)  dCol = '#e8e8e8';
           else if (s.delta < 0)           dCol = '#22dd66';
           else                            dCol = '#ff4444';
+          const deltaTxt = (s.delta >= 0 ? '+' : '') + s.delta.toFixed(2);
           ctx.fillStyle = dCol;
-          ctx.font      = `bold ${fsRow}px 'Segoe UI', sans-serif`;
-          ctx.fillText((s.delta >= 0 ? '+' : '') + s.delta.toFixed(2), COL_DIFF, rowY);
-          ctx.font      = `${fsRow}px 'Segoe UI', sans-serif`;
+          ctx.font      = `bold ${GaugeBase.fitFontSize(ctx, deltaTxt, fsRow, 'bold', COL_BUDGET)}px 'Segoe UI', sans-serif`;
+          ctx.fillText(deltaTxt, COL_DIFF, rowY);
         }
       } else {
         ctx.fillStyle = '#444444';
+        ctx.font      = `${fsRow}px 'Segoe UI', sans-serif`;
         ctx.fillText('\u2014', COL_CUR, rowY);
         ctx.fillText('\u2014', COL_DIFF, rowY);
       }

--- a/frontend/tests/gauge_base.test.js
+++ b/frontend/tests/gauge_base.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { loadGaugeBase, makeFakeCanvasCtx } from './helpers.js';
+
+describe('GaugeBase.fitFontSize', () => {
+  const GaugeBase = loadGaugeBase();
+
+  it('returns the candidate size unchanged when the text already fits', () => {
+    const ctx = makeFakeCanvasCtx();
+    const size = GaugeBase.fitFontSize(ctx, '5', 20, 'bold', 500);
+    expect(size).toBe(20);
+  });
+
+  it('shrinks the size when the text is wider than the budget', () => {
+    const ctx = makeFakeCanvasCtx();
+    const size = GaugeBase.fitFontSize(ctx, '123,456,789', 34, 'bold', 60);
+    expect(size).toBeLessThan(34);
+  });
+
+  it('shrinks proportionally more for longer strings at the same budget', () => {
+    const ctx = makeFakeCanvasCtx();
+    const shortFit = GaugeBase.fitFontSize(ctx, '12', 34, 'bold', 60);
+    const longFit  = GaugeBase.fitFontSize(ctx, '123456789', 34, 'bold', 60);
+    expect(longFit).toBeLessThanOrEqual(shortFit);
+  });
+
+  it('never returns less than minFontSizePx', () => {
+    const ctx = makeFakeCanvasCtx();
+    const size = GaugeBase.fitFontSize(ctx, 'a very long string indeed', 40, 'bold', 2, 6);
+    expect(size).toBe(6);
+  });
+
+  it('never grows past the candidate size when the candidate is already below minFontSizePx', () => {
+    const ctx = makeFakeCanvasCtx();
+    const size = GaugeBase.fitFontSize(ctx, '123456789', 5, 'bold', 2, 6);
+    expect(size).toBeLessThanOrEqual(5);
+  });
+
+  it('sets ctx.font using the requested font family', () => {
+    const ctx = makeFakeCanvasCtx();
+    GaugeBase.fitFontSize(ctx, '1:23.456', 20, 'bold', 500, 8, "'Consolas', monospace");
+    expect(ctx.font).toContain('Consolas');
+  });
+});

--- a/frontend/tests/helpers.js
+++ b/frontend/tests/helpers.js
@@ -37,6 +37,34 @@ export function loadPage(relPath) {
   new Function(code)();
 }
 
+/**
+ * Load gauges/base.js and return the GaugeBase namespace object.
+ * base.js defines top-level `const GaugeBase = {...}` with no IIFE wrapper,
+ * so we return it directly from the Function body (same trick as loadState).
+ */
+export function loadGaugeBase() {
+  const code = readFileSync(resolve(JS_ROOT, 'gauges/base.js'), 'utf8');
+  return new Function(`${code}; return GaugeBase;`)();
+}
+
+/**
+ * Minimal CanvasRenderingContext2D stand-in for testing font-fit logic.
+ * jsdom does not implement real text metrics, so measureText() here
+ * approximates width from the font-size number embedded in ctx.font
+ * (set as "<weight> <size>px <family>") and the string length — good enough
+ * to unit-test shrink/clamp behaviour, not for pixel-perfect assertions.
+ */
+export function makeFakeCanvasCtx() {
+  return {
+    font: '',
+    measureText(text) {
+      const m = /(\d+(?:\.\d+)?)px/.exec(this.font);
+      const size = m ? parseFloat(m[1]) : 10;
+      return { width: text.length * size * 0.55 };
+    },
+  };
+}
+
 // ── Mock factories ─────────────────────────────────────────────────────────────
 
 /**

--- a/main.py
+++ b/main.py
@@ -12,6 +12,13 @@ import os
 import sys
 from pathlib import Path
 
+import matplotlib
+# Force the headless Agg backend before any other import can trigger matplotlib's
+# default backend auto-selection (which may pick a GUI toolkit backend that isn't
+# available in a windowless/Linux environment). Every styles/*.py module also sets
+# this, but setting it here first avoids relying on import order.
+matplotlib.use('Agg')
+
 
 def _setup_logging() -> None:
     log_dir = Path.home() / '.openlap' / 'logs'

--- a/overlay_utils.py
+++ b/overlay_utils.py
@@ -15,6 +15,27 @@ def scale_factor(vw: int, vh: int, base_w: int = 1920, base_h: int = 1080) -> fl
     return math.sqrt((vw * vh) / (base_w * base_h))
 
 
+def fit_text_to_width(fig, text_obj, max_width_px: float, min_fontsize: float = 6) -> float:
+    """
+    Shrink a matplotlib Text artist's fontsize in place so its rendered width
+    does not exceed max_width_px. Mirrors fitFontSize() in frontend/js/gauges/base.js.
+
+    Uses get_window_extent(), which only needs a renderer (via
+    fig.canvas.get_renderer()) to compute real glyph metrics — it does not require
+    a full figure draw, so this is cheap to call once per text item per frame.
+    """
+    renderer = fig.canvas.get_renderer()
+    width = text_obj.get_window_extent(renderer=renderer).width
+    if width <= max_width_px or width <= 0:
+        return text_obj.get_fontsize()
+    fs = text_obj.get_fontsize()
+    # Never grow past fs — if fs is already <= min_fontsize, the best we can do
+    # is leave it alone rather than clamp upward to min_fontsize.
+    new_fs = min(fs, max(min_fontsize, fs * (max_width_px / width)))
+    text_obj.set_fontsize(new_fs)
+    return new_fs
+
+
 def fig_to_rgba(fig, size: Tuple[int, int]) -> np.ndarray:
     """
     Convert a matplotlib figure to an RGBA numpy array at exactly (w, h) pixels.

--- a/styles/gauge_bar.py
+++ b/styles/gauge_bar.py
@@ -19,7 +19,7 @@ from matplotlib.patches import FancyBboxPatch
 
 
 def render(data: dict, w: int, h: int):
-    from overlay_utils import fig_to_rgba, scale_factor
+    from overlay_utils import fig_to_rgba, scale_factor, fit_text_to_width
 
     value     = data.get('value',       0.0)
     hist      = data.get('history_vals', [value])
@@ -101,9 +101,10 @@ def render(data: dict, w: int, h: int):
 
     # Value text (middle zone: 0.34 – 0.48, safely between bar and sparkline)
     val_str = f"{value:.1f} {unit}" if unit else f"{value:.1f}"
-    ax.text(0.50, 0.41, val_str,
+    value_text = ax.text(0.50, 0.41, val_str,
             ha='center', va='center', color=val_col,
             fontsize=fs_val, fontweight='bold', fontfamily='sans-serif')
+    fit_text_to_width(fig, value_text, bar_w * w)
 
     # Sparkline (bottom zone: 0.05 – 0.27, never reaches value text)
     # High values plot at top of zone, low values at bottom — correct orientation.

--- a/styles/gauge_compare.py
+++ b/styles/gauge_compare.py
@@ -24,7 +24,7 @@ from matplotlib.patches import FancyBboxPatch
 
 
 def render(data: dict, w: int, h: int):
-    from overlay_utils import fig_to_rgba, scale_factor
+    from overlay_utils import fig_to_rgba, scale_factor, fit_text_to_width
 
     value     = data.get('value',            0.0)
     hist      = data.get('history_vals',     [value])
@@ -131,10 +131,12 @@ def render(data: dict, w: int, h: int):
     else:
         val_str = f"{value:.2f}"
 
-    ax_bg.text(0.97, 0.88, val_str,
+    # Budget is the panel right of the chart area (chart occupies x 0.04–0.74).
+    value_text = ax_bg.text(0.97, 0.88, val_str,
                ha='right', va='top', color=line_col,
                fontsize=fs_val, fontweight='bold', fontfamily='sans-serif',
                transform=ax_bg.transAxes)
+    fit_text_to_width(fig, value_text, (0.97 - 0.74) * w)
     if unit:
         ax_bg.text(0.97, 0.60, unit,
                    ha='right', va='center', color=unit_col,

--- a/styles/gauge_delta.py
+++ b/styles/gauge_delta.py
@@ -36,7 +36,7 @@ def _delta_colour(delta: float) -> str:
 
 
 def render(data: dict, w: int, h: int):
-    from overlay_utils import fig_to_rgba, scale_factor
+    from overlay_utils import fig_to_rgba, scale_factor, fit_text_to_width
 
     value    = data.get('value', 0.0)
     history  = data.get('history_vals', [0.0])
@@ -80,9 +80,10 @@ def render(data: dict, w: int, h: int):
             ha='center', va='center', color=label_col,
             fontsize=fs_label, fontfamily='sans-serif')
 
-    ax.text(0.50, 0.46, txt,
+    value_text = ax.text(0.50, 0.46, txt,
             ha='center', va='center', color=colour,
             fontsize=fs_value, fontweight='bold', fontfamily='sans-serif')
+    fit_text_to_width(fig, value_text, w * 0.90)
 
     # ── Sparkline (delta history trend) ───────────────────────────────────────
     if len(history) >= 2:

--- a/styles/gauge_dial.py
+++ b/styles/gauge_dial.py
@@ -20,7 +20,7 @@ from matplotlib.patches import FancyBboxPatch, Arc, FancyArrowPatch
 
 
 def render(data: dict, w: int, h: int):
-    from overlay_utils import fig_to_rgba, scale_factor
+    from overlay_utils import fig_to_rgba, scale_factor, fit_text_to_width
 
     value     = data.get('value',     0.0)
     label     = data.get('label',     '')
@@ -127,9 +127,18 @@ def render(data: dict, w: int, h: int):
     else:
         val_str = f"{value:.2f}"
 
-    ax.text(0, -0.18, val_str,
+    # Horizontal budget = chord of the track ring at the value text's vertical
+    # offset (axes units converted to px), so long strings shrink instead of
+    # poking outside the ring. Mirrors the same calc in dial.js.
+    value_dy    = 0.18
+    chord_half  = (max(0.0, R_TRACK ** 2 - value_dy ** 2)) ** 0.5
+    px_per_unit = w / 2.4  # xlim spans -1.2..1.2
+    value_max_width = chord_half * 2 * px_per_unit * 0.85
+
+    value_text = ax.text(0, -0.18, val_str,
             ha='center', va='center', color=text_col,
             fontsize=fs_value, fontweight='bold', fontfamily='sans-serif', zorder=6)
+    fit_text_to_width(fig, value_text, value_max_width)
     ax.text(0, -0.72, unit,
             ha='center', va='center', color=unit_col,
             fontsize=fs_unit, fontfamily='sans-serif', zorder=6)

--- a/styles/gauge_gmeter.py
+++ b/styles/gauge_gmeter.py
@@ -24,7 +24,7 @@ from matplotlib.patches import Circle, FancyBboxPatch
 
 
 def render(data: dict, w: int, h: int):
-    from overlay_utils import fig_to_rgba
+    from overlay_utils import fig_to_rgba, fit_text_to_width
 
     gx_now   = float(data.get('value',       0.0))
     gy_now   = float(data.get('value_gy',    0.0))
@@ -95,11 +95,12 @@ def render(data: dict, w: int, h: int):
 
     # Current G readout — compact, shown at the bottom of the bg area
     fs_val = max(5, int(size * 0.065))
-    ax_bg.text(0.50, 0.06,
+    g_readout_text = ax_bg.text(0.50, 0.06,
                f'{gx_now:+.2f}  /  {gy_now:+.2f}',
                ha='center', va='bottom', color='#ccccdd',
                fontsize=fs_val, fontfamily='sans-serif',
                transform=ax_bg.transAxes)
+    fit_text_to_width(fig, g_readout_text, w * 0.90)
 
     # History trace (fading)
     n_trace = min(60, len(gx_hist))

--- a/styles/gauge_info.py
+++ b/styles/gauge_info.py
@@ -20,7 +20,7 @@ from matplotlib.patches import FancyBboxPatch
 
 
 def render(data: dict, w: int, h: int):
-    from overlay_utils import fig_to_rgba
+    from overlay_utils import fig_to_rgba, fit_text_to_width
 
     T         = data.get('_tc', {})
     bg_rgba   = T.get('bg_rgba',      (0.04, 0.06, 0.10, 0.78))
@@ -103,8 +103,9 @@ def render(data: dict, w: int, h: int):
         ax.text(pad_l, y_lbl, lbl,
                 ha='left', va='center', color=label_col,
                 fontsize=fs_label, zorder=4)
-        ax.text(pad_l, y_val, val,
+        value_text = ax.text(pad_l, y_val, val,
                 ha='left', va='center', color=text_col,
                 fontsize=fs_value, fontweight='bold', zorder=4)
+        fit_text_to_width(fig, value_text, w * (1 - 2 * pad_l))
 
     return fig_to_rgba(fig, (w, h))

--- a/styles/gauge_lap_scoreboard.py
+++ b/styles/gauge_lap_scoreboard.py
@@ -25,7 +25,7 @@ def _fmt_time(secs: float) -> str:
 
 
 def render(data: dict, w: int, h: int):
-    from overlay_utils import fig_to_rgba
+    from overlay_utils import fig_to_rgba, fit_text_to_width
 
     T         = data.get('_tc', {})
     bg_rgba   = T.get('bg_rgba',      (0.04, 0.06, 0.10, 0.78))
@@ -116,9 +116,12 @@ def render(data: dict, w: int, h: int):
         ax.text(pad_l, y_lbl, lbl,
                 ha='left', va='center', color=label_col,
                 fontsize=fs_label, fontfamily='sans-serif', zorder=4)
-        ax.text(0.97, y_val, val,
+        value_text = ax.text(0.97, y_val, val,
                 ha='right', va='center', color=col,
                 fontsize=fs_value, fontweight='bold',
                 fontfamily='monospace', zorder=4)
+        # Budget is the right ~55% of the row so long values shrink instead of
+        # running under the label column. Mirrors scoreboard.js.
+        fit_text_to_width(fig, value_text, w * 0.55)
 
     return fig_to_rgba(fig, (w, h))

--- a/styles/gauge_lean.py
+++ b/styles/gauge_lean.py
@@ -23,7 +23,7 @@ from matplotlib.transforms import Affine2D
 
 
 def render(data: dict, w: int, h: int):
-    from overlay_utils import fig_to_rgba, scale_factor
+    from overlay_utils import fig_to_rgba, scale_factor, fit_text_to_width
 
     value   = data.get('value',   0.0)
     label   = data.get('label',   'Lean')
@@ -106,9 +106,17 @@ def render(data: dict, w: int, h: int):
     direction = 'R' if value > 0 else ('L' if value < 0 else '')
     val_str   = f"{direction}{abs_lean:.1f}{unit}"
 
-    ax.text(0, -0.82, val_str,
+    # Horizontal budget = chord of the background circle at the value text's
+    # vertical offset (axes units converted to px). Mirrors lean.js.
+    value_dy    = 0.82
+    chord_half  = (max(0.0, 0.98 ** 2 - value_dy ** 2)) ** 0.5
+    px_per_unit = w / 2.0  # xlim spans -1..1
+    value_max_width = chord_half * 2 * px_per_unit * 0.85
+
+    value_text = ax.text(0, -0.82, val_str,
             ha='center', va='center', color=val_col,
             fontsize=fs_val, fontweight='bold', fontfamily='sans-serif', zorder=6)
+    fit_text_to_width(fig, value_text, value_max_width)
     ax.text(0, 0.85, label.upper(),
             ha='center', va='center', color=label_col,
             fontsize=fs_label, fontfamily='sans-serif', zorder=6)

--- a/styles/gauge_line.py
+++ b/styles/gauge_line.py
@@ -21,7 +21,7 @@ from matplotlib.patches import FancyBboxPatch
 
 
 def render(data: dict, w: int, h: int):
-    from overlay_utils import fig_to_rgba, scale_factor
+    from overlay_utils import fig_to_rgba, scale_factor, fit_text_to_width
 
     value     = data.get('value',       0.0)
     hist      = data.get('history_vals', [value])
@@ -111,10 +111,12 @@ def render(data: dict, w: int, h: int):
     else:
         val_str = f"{value:.2f}"
 
-    ax_bg.text(0.95, 0.56, val_str,
+    # Budget is the panel right of the chart area (chart occupies x 0.04–0.72).
+    value_text = ax_bg.text(0.95, 0.56, val_str,
                ha='right', va='center', color=line_col,
                fontsize=fs_val, fontweight='bold', fontfamily='sans-serif',
                transform=ax_bg.transAxes)
+    fit_text_to_width(fig, value_text, (0.95 - 0.72) * w)
     if unit:
         ax_bg.text(0.95, 0.28, unit,
                    ha='right', va='center', color=unit_col,

--- a/styles/gauge_multiline.py
+++ b/styles/gauge_multiline.py
@@ -51,7 +51,7 @@ def _delta_colour(value: float) -> str:
 
 
 def render(data: dict, w: int, h: int):
-    from overlay_utils import fig_to_rgba, scale_factor
+    from overlay_utils import fig_to_rgba, scale_factor, fit_text_to_width
 
     entries = data.get('multi_channels', [])
     T       = data.get('_tc', {})
@@ -177,10 +177,12 @@ def render(data: dict, w: int, h: int):
         # Single combined line: "LABEL  val unit"
         short_label = label[:6].upper()
         combined    = f'{short_label:<6}  {val_str}'
-        ax_bg.text(legend_x + 0.032, y_centre,
+        text_x      = legend_x + 0.032
+        combined_text = ax_bg.text(text_x, y_centre,
                    combined,
                    ha='left', va='center', color=colour,
                    fontsize=fs_leg, fontweight='bold', fontfamily='sans-serif',
                    transform=ax_bg.transAxes)
+        fit_text_to_width(fig, combined_text, (1.0 - text_x - 0.02) * w)
 
     return fig_to_rgba(fig, (w, h))

--- a/styles/gauge_numeric.py
+++ b/styles/gauge_numeric.py
@@ -18,7 +18,7 @@ from matplotlib.patches import FancyBboxPatch
 
 
 def render(data: dict, w: int, h: int):
-    from overlay_utils import fig_to_rgba, scale_factor
+    from overlay_utils import fig_to_rgba, scale_factor, fit_text_to_width
 
     value   = data.get('value',   0.0)
     label   = data.get('label',   '')
@@ -70,9 +70,10 @@ def render(data: dict, w: int, h: int):
     ax.text(0.50, 0.78, label.upper(),
             ha='center', va='center', color=label_col,
             fontsize=fs_label, fontfamily='sans-serif')
-    ax.text(0.50, 0.50, txt,
+    value_text = ax.text(0.50, 0.50, txt,
             ha='center', va='center', color=text_col,
             fontsize=fs_value, fontweight='bold', fontfamily='sans-serif')
+    fit_text_to_width(fig, value_text, w * 0.90)
     ax.text(0.50, 0.24, unit,
             ha='center', va='center', color=unit_col,
             fontsize=fs_unit, fontfamily='sans-serif')

--- a/styles/gauge_sector_bar.py
+++ b/styles/gauge_sector_bar.py
@@ -51,7 +51,7 @@ def _sector_colour(delta: float):
 
 
 def render(data: dict, w: int, h: int):
-    from overlay_utils import fig_to_rgba, scale_factor
+    from overlay_utils import fig_to_rgba, scale_factor, fit_text_to_width
 
     sectors = data.get('sectors', [])
     T       = data.get('_tc', {})
@@ -127,11 +127,12 @@ def render(data: dict, w: int, h: int):
 
         # Delta (centre)
         sign = '+' if delta >= 0 else ''
-        ax.text(cursor + box_w / 2, (BOX_Y1 + BOX_Y2) / 2,
+        delta_text = ax.text(cursor + box_w / 2, (BOX_Y1 + BOX_Y2) / 2,
                 f'{sign}{delta:.2f}',
                 ha='center', va='center',
                 color='white', fontweight='bold',
                 fontsize=fs, fontfamily='sans-serif')
+        fit_text_to_width(fig, delta_text, box_w * w * 0.90)
 
         cursor += box_w + GAP
 

--- a/styles/gauge_splits.py
+++ b/styles/gauge_splits.py
@@ -32,7 +32,7 @@ from matplotlib.patches import FancyBboxPatch, Rectangle
 
 
 def render(data: dict, w: int, h: int):
-    from overlay_utils import fig_to_rgba, scale_factor
+    from overlay_utils import fig_to_rgba, scale_factor, fit_text_to_width
 
     cur_elapsed = data.get('value',   0.0)
     sectors     = data.get('sectors', [])
@@ -64,6 +64,8 @@ def render(data: dict, w: int, h: int):
     fs_title  = max(5, min(int(8 * sc), int(w * 0.09)))
     fs_row    = max(5, min(int(9 * sc), int(w * 0.09)))
     fs_hdr    = max(4, min(int(6 * sc), int(w * 0.075)))
+    # Per-column width budget for shrink-to-fit (columns are ~0.24-0.26 apart)
+    col_budget = w * 0.20
 
     ax.text(0.50, 0.93, 'SPLITS',
             ha='center', va='center', color=label_col,
@@ -111,19 +113,22 @@ def render(data: dict, w: int, h: int):
 
         row_y = y + row_h * 0.5
 
-        ax.text(0.12, row_y, f'S{num}',
+        s_num_text = ax.text(0.12, row_y, f'S{num}',
                 ha='center', va='center', color=text_col,
                 fontsize=fs_row, fontfamily='sans-serif')
+        fit_text_to_width(fig, s_num_text, col_budget)
 
         ref_str = f'{ref_t:.2f}' if ref_t is not None else '\u2014'
-        ax.text(0.38, row_y, ref_str,
+        ref_text = ax.text(0.38, row_y, ref_str,
                 ha='center', va='center', color='#888888',
                 fontsize=fs_row, fontfamily='sans-serif')
+        fit_text_to_width(fig, ref_text, col_budget)
 
         if cur_t is not None:
-            ax.text(0.62, row_y, f'{cur_t:.2f}',
+            cur_text = ax.text(0.62, row_y, f'{cur_t:.2f}',
                     ha='center', va='center', color=text_col,
                     fontsize=fs_row, fontfamily='sans-serif')
+            fit_text_to_width(fig, cur_text, col_budget)
             if delta is not None:
                 if abs(delta) < 0.01:
                     d_col = '#e8e8e8'
@@ -131,9 +136,10 @@ def render(data: dict, w: int, h: int):
                     d_col = '#22dd66'
                 else:
                     d_col = '#ff4444'
-                ax.text(0.87, row_y, f'{delta:+.2f}',
+                delta_text = ax.text(0.87, row_y, f'{delta:+.2f}',
                         ha='center', va='center', color=d_col,
                         fontsize=fs_row, fontweight='bold', fontfamily='sans-serif')
+                fit_text_to_width(fig, delta_text, col_budget)
         else:
             dim = '#444444'
             ax.text(0.62, row_y, '\u2014', ha='center', va='center',

--- a/tests/test_style_text_fit.py
+++ b/tests/test_style_text_fit.py
@@ -1,0 +1,82 @@
+"""
+Tests for overlay_utils.fit_text_to_width() — the shrink-to-fit helper that
+replaces the old box-dimension-only font sizing (which let long value strings
+overflow gauge boundaries; see gauge_numeric.py etc.).
+"""
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import pytest
+
+from overlay_utils import fit_text_to_width
+
+
+def _make_text(text, fontsize, fig_w_px=200, fig_h_px=100):
+    dpi = 100
+    fig = plt.figure(figsize=(fig_w_px / dpi, fig_h_px / dpi), dpi=dpi)
+    ax = fig.add_axes([0, 0, 1, 1])
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.axis('off')
+    text_obj = ax.text(0.5, 0.5, text, ha='center', va='center', fontsize=fontsize)
+    return fig, text_obj
+
+
+def test_shrinks_when_too_wide():
+    fig, text_obj = _make_text('123,456,789', fontsize=34)
+    renderer = fig.canvas.get_renderer()
+    width_before = text_obj.get_window_extent(renderer=renderer).width
+
+    budget = 60
+    new_fs = fit_text_to_width(fig, text_obj, budget)
+
+    assert new_fs < 34
+    assert text_obj.get_fontsize() == pytest.approx(new_fs)
+    renderer2 = fig.canvas.get_renderer()
+    width_after = text_obj.get_window_extent(renderer=renderer2).width
+    assert width_after <= budget * 1.05  # small tolerance for the single-shot linear correction
+    plt.close(fig)
+    assert width_before > budget  # sanity: it really was too wide to start with
+
+
+def test_noop_when_it_already_fits():
+    fig, text_obj = _make_text('5', fontsize=12)
+    new_fs = fit_text_to_width(fig, text_obj, max_width_px=500)
+    assert new_fs == 12
+    assert text_obj.get_fontsize() == 12
+    plt.close(fig)
+
+
+def test_clamped_to_min_fontsize():
+    fig, text_obj = _make_text('a very long string that will not fit', fontsize=40)
+    new_fs = fit_text_to_width(fig, text_obj, max_width_px=2, min_fontsize=6)
+    assert new_fs == 6
+    assert text_obj.get_fontsize() == 6
+    plt.close(fig)
+
+
+def test_never_grows_past_candidate_when_candidate_below_min_fontsize():
+    """Regression: if the starting fontsize is already below min_fontsize (can
+    happen for tightly-packed table rows), shrinking further must not clamp
+    the result *up* to min_fontsize — that would grow the text instead of
+    shrinking it, defeating the whole point of this helper."""
+    fig, text_obj = _make_text('123456789', fontsize=5)
+    new_fs = fit_text_to_width(fig, text_obj, max_width_px=2, min_fontsize=6)
+    assert new_fs <= 5
+    plt.close(fig)
+
+
+@pytest.mark.parametrize('style_module,style_name,data', [
+    ('gauge_numeric', 'Numeric', {'value': 123456.789, 'label': 'RPM', 'unit': 'rpm', 'channel': 'rpm'}),
+    ('gauge_dial', 'Dial', {'value': -123456.789, 'label': 'Speed', 'unit': 'km/h', 'channel': 'speed',
+                             'min_val': 0, 'max_val': 300}),
+    ('gauge_delta', 'Delta', {'value': -12345.6789, 'label': 'Delta'}),
+    ('gauge_lean', 'Lean', {'value': -89.999, 'label': 'Lean', 'unit': '°'}),
+])
+def test_extreme_values_render_without_error_at_small_size(style_module, style_name, data):
+    """Regression guard: extreme/long value strings must not raise or distort
+    output shape when rendered at a small gauge size (where overflow used to
+    be most visible)."""
+    import style_registry
+    img = style_registry.render_style('gauge', style_name, data, 80, 100)
+    assert img.shape == (100, 80, 4)


### PR DESCRIPTION
## Summary
- PR #10 forced the Agg backend and tweaked matplotlib rcParams, but neither actually touches font sizing — value text was still drawn at a fixed size derived only from a gauge-size scale factor, never checked against the actual rendered width or the circle/box it sits in.
- Adds `fit_text_to_width()` (`overlay_utils.py`) and `fitFontSize()` (`base.js`) — real measure-then-shrink helpers — and applies them at the value-text draw call across all 13 gauges that render variable-length text, in both the JS canvas and matplotlib rendering stacks.
- Keeps the one legitimate part of PR #10 (forcing `matplotlib.use('Agg')` early in `main.py`, before any other import can trigger backend auto-selection).

Closes #10.

## Test plan
- [x] `python -m pytest tests/ -q`
- [x] `npm run test:run`
- [ ] @jorlandobr to confirm the lean/dial overflow from #10's screenshots is resolved on Linux