### PR TITLE
Fix VideoToolbox ignoring the Quality (CRF) setting on macOS

### DIFF
--- a/tests/test_video_renderer.py
+++ b/tests/test_video_renderer.py
@@ -290,3 +290,65 @@ class TestConcatVideosProgress:
                               progress_cb=lambda pct, msg: None,
                               stall_timeout_s=0.05)
         assert procs and all(p.kill.assert_called_once() is None for p in procs)
+
+
+# ── quality_args ───────────────────────────────────────────────────────────────
+
+class TestQualityArgs:
+    """Constant-quality flag selection per encoder family.
+
+    The VideoToolbox cases are the reason this helper exists: ffmpeg accepts
+    -qp for h264_videotoolbox but ignores it, so the Quality slider silently
+    did nothing on macOS. These assertions run anywhere — no VideoToolbox
+    hardware or ffmpeg needed.
+    """
+
+    def test_libx264_uses_crf(self):
+        from video_renderer import quality_args
+        assert quality_args('libx264', 18) == ['-crf', '18']
+
+    def test_nvenc_uses_cq(self):
+        from video_renderer import quality_args
+        assert quality_args('h264_nvenc', 20) == ['-rc', 'vbr', '-cq', '20', '-b:v', '0']
+
+    def test_videotoolbox_uses_qv_not_qp(self):
+        from video_renderer import quality_args
+        args = quality_args('h264_videotoolbox', 18)
+        assert '-qp' not in args
+        assert args[0] == '-q:v'
+
+    def test_videotoolbox_scale_is_inverted(self):
+        """Higher CRF means worse quality; higher -q:v means better."""
+        from video_renderer import quality_args
+        best  = int(quality_args('h264_videotoolbox', 12)[1])
+        worst = int(quality_args('h264_videotoolbox', 32)[1])
+        assert best > worst
+
+    def test_videotoolbox_matches_measured_libx264_equivalents(self):
+        """Anchors: measured against libx264 output size on the same source.
+
+        crf 12 -> q:v 76 and crf 18 -> q:v 65 each landed within ~1.5% of the
+        equivalent libx264 encode. If the mapping is reworked, re-measure
+        rather than just updating these numbers.
+        """
+        from video_renderer import quality_args
+        assert quality_args('h264_videotoolbox', 12) == ['-q:v', '76']
+        assert quality_args('h264_videotoolbox', 18) == ['-q:v', '65']
+
+    def test_videotoolbox_clamped_to_valid_range(self):
+        """-q:v outside 1-100 is rejected by ffmpeg; CRF is not hard-bounded."""
+        from video_renderer import quality_args
+        assert quality_args('h264_videotoolbox', 0)[1]   == '100'
+        assert quality_args('h264_videotoolbox', 51)[1]  == '1'
+        assert quality_args('h264_videotoolbox', 99)[1]  == '1'
+        assert quality_args('h264_videotoolbox', -10)[1] == '100'
+
+    def test_hevc_videotoolbox_also_covered(self):
+        from video_renderer import quality_args
+        assert quality_args('hevc_videotoolbox', 18) == ['-q:v', '65']
+
+    def test_other_encoders_unchanged(self):
+        """AMF/QSV/libx265 honour -qp — this fix must not alter them."""
+        from video_renderer import quality_args
+        for enc in ('libx265', 'h264_amf', 'h264_qsv', 'hevc_nvenc'):
+            assert quality_args(enc, 22) == ['-qp', '22']

--- a/video_renderer.py
+++ b/video_renderer.py
@@ -161,6 +161,34 @@ def concat_videos(input_files: List[str], output: str,
         os.unlink(concat_file)
 
 
+def quality_args(encoder: str, crf: int) -> list:
+    """Map the UI's CRF setting to the constant-quality flag *encoder* expects.
+
+    Every encoder family spells constant quality differently, and picking the
+    wrong flag is not reliably an error: VideoToolbox *accepts* -qp and then
+    silently ignores it, so on macOS every export came out at the encoder's
+    own default quality no matter where the user put the Quality slider
+    (-qp 12 and -qp 32 produce byte-identical output). Other encoders that
+    fall through to -qp do honour it, so this only special-cases VideoToolbox.
+
+    VideoToolbox instead takes -q:v on a 1-100 scale where *higher is better* —
+    the inverse of CRF. Mapping linearly across H.264's 0-51 quantiser range
+    (crf 0 -> 100, crf 51 -> 0) tracks libx264's output closely over the upper
+    half of the UI's 12-32 slider: at crf 12 and 18 the resulting file lands
+    within ~1.5% of the equivalent libx264 encode. Below roughly crf 22 the
+    curve diverges and this mapping errs toward larger files, i.e. more
+    quality than asked for rather than less.
+    """
+    if encoder == 'libx264':
+        return ['-crf', str(crf)]
+    if encoder == 'h264_nvenc':
+        return ['-rc', 'vbr', '-cq', str(crf), '-b:v', '0']
+    if encoder.endswith('_videotoolbox'):
+        q = round((1.0 - crf / 51.0) * 100)
+        return ['-q:v', str(max(1, min(100, q)))]
+    return ['-qp', str(crf)]
+
+
 def mux_audio(raw_video: str, audio_source: str,
                output: str, encoder: str, crf: int = 18,
                audio_start: float = 0.0,
@@ -176,13 +204,7 @@ def mux_audio(raw_video: str, audio_source: str,
     """
     import threading, subprocess as _sp
 
-    # Quality args — nvenc uses -cq (constant quality, like CRF) not -qp (fixed QP)
-    if encoder == 'libx264':
-        q_arg = ['-crf', str(crf)]
-    elif encoder == 'h264_nvenc':
-        q_arg = ['-rc', 'vbr', '-cq', str(crf), '-b:v', '0']
-    else:
-        q_arg = ['-qp', str(crf)]
+    q_arg = quality_args(encoder, crf)
 
     # Force yuv420p: MJPG from OpenCV is yuvj420p (full-range) which hardware
     # encoders (nvenc/amf/qsv) reject.  Also ensure even dimensions.


### PR DESCRIPTION
## The bug

`mux_audio()` picks the constant-quality flag per encoder:

```python
if encoder == 'libx264':      q_arg = ['-crf', str(crf)]
elif encoder == 'h264_nvenc': q_arg = ['-rc','vbr','-cq',str(crf),'-b:v','0']
else:                         q_arg = ['-qp', str(crf)]   # ← videotoolbox lands here
```

ffmpeg **accepts** `-qp` for `h264_videotoolbox` and then ignores it. It's not an error, so nothing surfaces — but the Quality (CRF) slider in Settings has no effect whatsoever on macOS. Every export comes out at VideoToolbox's own default quality.

```
videotoolbox -qp 12  -> 121791 bytes
videotoolbox -qp 32  -> 121791 bytes   ← byte-identical
```

## The fix

VideoToolbox uses `-q:v` on a 1–100 scale where **higher is better** — the inverse of CRF. Mapped linearly across H.264's 0–51 quantiser range and clamped to 1–100.

I picked the mapping by measuring rather than guessing. Same source (1280x720, 4s), `-q:v` swept against libx264 at each CRF:

| CRF | libx264 | this mapping | result | diff |
|---|---|---|---|---|
| 12 | 6,327,650 B | `-q:v 76` | 6,324,274 B | 0.05% |
| 18 | 3,829,364 B | `-q:v 65` | 3,878,249 B | 1.3% |
| 26 | 1,524,801 B | `-q:v 49` | 1,896,310 B | +24% |
| 32 | 501,888 B | `-q:v 37` | 974,704 B | +94% |

It tracks libx264 very closely over the upper half of the UI's 12–32 slider (including the default of 18). Below roughly CRF 22 the curves diverge and this errs toward **larger** files — more quality than asked for rather than less, which seemed like the right direction to fail in.

I deliberately did **not** fit a curve to the measured points. That's one clip on one Apple Silicon machine, and VideoToolbox's behaviour varies across silicon generations and macOS versions; a fitted curve would be false precision. The linear map is one line, monotonic, and exact where it matters most. Happy to revisit if you'd rather have the low end tuned.

## Scope

Only VideoToolbox is special-cased. I checked that the other encoders falling through to `-qp` genuinely honour it, so none of their behaviour changes:

```
libx265 -qp 12 -> 9,112,212 bytes
libx265 -qp 32 -> 1,230,731 bytes   ← honoured, left alone
```

The logic is extracted into `quality_args()` so it's unit-testable on any platform — the 8 new tests need neither VideoToolbox hardware nor ffmpeg, so they run on the Windows CI runner too.

## Testing

- `pytest tests/ -q` → **578 passed, 26 skipped** on macOS (was 570 passed; +8 new)
- End-to-end re-encode through the real `quality_args()` output confirms the slider now moves: 6.3 MB → 3.9 MB → 1.9 MB → 974 KB across CRF 12/18/26/32, where previously all four were byte-identical

## Notes

Environment: macOS on Apple Silicon, Python 3.13, ffmpeg 8.1.2, `pip install -e ".[dev]"`.

While verifying this I also confirmed the rest of the macOS story is in good shape — the full suite passes and `python main.py` launches and loads cleanly. Two other things I noticed but left out to keep this PR focused, happy to open issues or follow-up PRs if useful:

1. `OpenLap.spec` can't be parsed on macOS at all — it raises `KeyError: 'LOCALAPPDATA'` in `_find_chromium_build()` before PyInstaller starts, so there's no path to a macOS build today.
2. 8 JS tests in `frontend/tests/data.test.js` fail from `localStorage` being undefined under vitest's jsdom (`data.js:1123` uses it as a bare global). That one is platform-independent — it should fail on Windows too.